### PR TITLE
Add nr of sales for user

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -214,6 +214,7 @@ type User @entity {
   sharesOwned: [PoolShare!] @derivedFrom(field: "userAddress")
   tokenBalancesOwned: [TokenBalance!] @derivedFrom(field: "userAddress")
   tokensOwned: [Datatoken!] @derivedFrom(field: "minter")
+  nrSales: Int
   poolTransactions: [PoolTransaction!] @derivedFrom(field: "userAddress")
   poolTransactionsTokenValues: [PoolTransactionTokenValues!]
     @derivedFrom(field: "userAddress")

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -237,6 +237,7 @@ export function updatePoolSwapVolume(
 export function createUserEntity(address: string): void {
   if (User.load(address) == null) {
     const user = new User(address)
+    user.nrSales = 0
     user.save()
   }
 }

--- a/src/mappings/datatoken.ts
+++ b/src/mappings/datatoken.ts
@@ -6,7 +6,8 @@ import {
   Global,
   PoolFactory,
   TokenBalance,
-  TokenOrder
+  TokenOrder,
+  User
 } from '../@types/schema'
 import {
   tokenToDecimal,
@@ -155,6 +156,11 @@ export function handleOrderStarted(event: OrderStarted): void {
   factory.orderCount = factory.orderCount.plus(BigInt.fromI32(1))
   factory.totalOrderVolume = factory.totalOrderVolume.plus(order.amount)
   factory.save()
+
+  const user = User.load(datatoken.minter)
+  user.nrSales = user.nrSales + 1
+  user.save()
+
   const gStats: Global | null = getGlobalStats()
   gStats.orderCount = factory.orderCount
   gStats.totalOrderVolume = factory.totalOrderVolume


### PR DESCRIPTION
Fixes https://github.com/oceanprotocol/ocean-subgraph/issues/230

Looks like : 
```
{
  "data": {
    "users": [
      {
        "id": "0x5612f2600a3e980b4065903a16bf0609c11f6a70",
        "nrSales": 72
      },
      {
        "id": "0x09262b812a05678a81778e60ee0154efcb7acfc7",
        "nrSales": 23
      },
      {
        "id": "0x903322c7e45a60d7c8c3ea236c5bea9af86310c7",
        "nrSales": 20
      },
      {
        "id": "0x43798154c31adf758d4098045a51828b60565420",
        "nrSales": 19
      },
      {
        "id": "0xe17d2a07efd5b112f4d675ea2d122ddb145d117b",
        "nrSales": 17
      }
```