### PR TITLE
Updating readme example queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This subgraph is deployed under `/subgraphs/name/oceanprotocol/ocean-subgraph/` 
 
 ```graphql
 {
-  nfts(orderBy: createdTimestamp, orderDirection: desc){
+  nfts(orderBy: createdTimestamp, orderDirection: desc, first: 1000){
     id,
     symbol,
     name,
@@ -87,11 +87,13 @@ This subgraph is deployed under `/subgraphs/name/oceanprotocol/ocean-subgraph/` 
 }
 ```
 
+> Note: 1000 is the maximum number of items the subgraph can return.
+
 **All Datatokens**
 
 ```graphql
 {
-  tokens(where: {isDatatoken: true}, orderBy: createdTimestamp, orderDirection: desc) {
+  tokens(where: {isDatatoken: true}, orderBy: createdTimestamp, orderDirection: desc, first: 1000) {
     id
     symbol
     name

--- a/README.md
+++ b/README.md
@@ -55,6 +55,24 @@ This subgraph is deployed under `/subgraphs/name/oceanprotocol/ocean-subgraph/` 
 }
 ```
 
+**Pools with the highest liquidity**
+
+```graphql
+{
+  pools(where: {datatokenLiquidity_gte: 1}, orderBy: baseTokenLiquidity, orderDirection: desc, first: 15) {
+    id
+    datatoken {
+      address
+    }
+    baseToken {
+      symbol
+    }
+    baseTokenLiquidity
+    datatokenLiquidity
+  }
+}
+```
+
 **All Data NFTs**
 
 ```graphql
@@ -102,24 +120,39 @@ This subgraph is deployed under `/subgraphs/name/oceanprotocol/ocean-subgraph/` 
   }
 ```
 
-> Note: all ETH addresses like `$userAddress` in above example need to be passed in lowercase.
+> Note: all ETH addresses like `$user` in above example need to be passed as a lowercase string.
 
-**Pools with the highest liquidity**
+**All pool transactions for a given user in an individual pool**
 
 ```graphql
 {
-  pools(where: {datatokenLiquidity_gte: 1}, orderBy: baseTokenLiquidity, orderDirection: desc, first: 15) {
-    id
-    datatoken {
-      address
+    poolTransactions(
+      orderBy: timestamp
+      orderDirection: desc
+      where: { pool: $pool, user: $user }
+      first: 1000
+    ) {
+      baseToken {
+        symbol
+        address
+      }
+      baseTokenValue
+      datatoken {
+        symbol
+        address
+      }
+      datatokenValue
+      type
+      tx
+      timestamp
+      pool {
+        datatoken {
+          id
+        }
+        id
+      }
     }
-    baseToken {
-      symbol
-    }
-    baseTokenLiquidity
-    datatokenLiquidity
   }
-}
 ```
 
 ## 🏊 Development on Barge

--- a/README.md
+++ b/README.md
@@ -41,13 +41,16 @@ This subgraph is deployed under `/subgraphs/name/oceanprotocol/ocean-subgraph/` 
 
 ```graphql
 {
-  pools(orderBy: oceanReserve, orderDirection: desc) {
-    consumePrice
-    datatokenReserve
-    oceanReserve
-    spotPrice
-    swapFee
-    transactionCount
+  pools(orderBy: baseTokenLiquidity, orderDirection: desc) {
+    id
+    datatoken {
+      address
+    }
+    baseToken {
+      symbol
+    }
+    baseTokenLiquidity
+    datatokenLiquidity
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ This subgraph is deployed under `/subgraphs/name/oceanprotocol/ocean-subgraph/` 
   }
 ```
 
+> Note: all ETH addresses like `$pool` and `$user` in above example need to be passed as a lowercase string.
+
 ## 🏊 Development on Barge
 
 

--- a/README.md
+++ b/README.md
@@ -55,18 +55,16 @@ This subgraph is deployed under `/subgraphs/name/oceanprotocol/ocean-subgraph/` 
 }
 ```
 
-**All datatokens**
+**All Data NFTs**
 
 ```graphql
 {
-  datatokens(orderBy: createTime, orderDirection: desc) {
-    address
-    symbol
-    name
-    cap
-    supply
-    publisher
-    holderCount
+  nfts(orderBy: createdTimestamp, orderDirection: desc){
+    id,
+    symbol,
+    name,
+    creator,
+    createdTimestamp
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -84,7 +84,23 @@ This subgraph is deployed under `/subgraphs/name/oceanprotocol/ocean-subgraph/` 
 
 > Note: all ETH addresses like `$userAddress` in above example need to be passed in lowercase.
 
+**Pools with the highest liquidity**
 
+```graphql
+{
+  pools(where: {datatokenLiquidity_gte: 1}, orderBy: baseTokenLiquidity, orderDirection: desc, first: 15) {
+    id
+    datatoken {
+      address
+    }
+    baseToken {
+      symbol
+    }
+    baseTokenLiquidity
+    datatokenLiquidity
+  }
+}
+```
 
 ## 🏊 Development on Barge
 

--- a/README.md
+++ b/README.md
@@ -73,14 +73,33 @@ This subgraph is deployed under `/subgraphs/name/oceanprotocol/ocean-subgraph/` 
 
 ```graphql
 {
-  poolTransactions(
-    where: { userAddressStr: $userAddress }
-    orderBy: timestamp
-    orderDirection: desc
-  ) {
-    poolAddressStr
+    poolTransactions(
+      orderBy: timestamp
+      orderDirection: desc
+      where: { user: $user }
+      first: 1000
+    ) {
+      baseToken {
+        symbol
+        address
+      }
+      baseTokenValue
+      datatoken {
+        symbol
+        address
+      }
+      datatokenValue
+      type
+      tx
+      timestamp
+      pool {
+        datatoken {
+          id
+        }
+        id
+      }
+    }
   }
-}
 ```
 
 > Note: all ETH addresses like `$userAddress` in above example need to be passed in lowercase.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ This subgraph is deployed under `/subgraphs/name/oceanprotocol/ocean-subgraph/` 
 }
 ```
 
+**All Datatokens**
+
+```graphql
+{
+  tokens(where: {isDatatoken: true}, orderBy: createdTimestamp, orderDirection: desc) {
+    id
+    symbol
+    name
+    address
+    holderCount
+  }
+}
+```
+
 **All pool transactions for a given user**
 
 ```graphql


### PR DESCRIPTION
Fixes #386 

Changes proposed in this PR:

- Updating readme example queries so that they work with the V4 subgraph. Previously the examples were still for the V3 subgraph.