### PR TITLE
Using main branch of barge for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           repository: 'oceanprotocol/barge'
           path: 'barge'
-          ref: v4
+          ref: main
 
       - name: Login to Docker Hub
         if: ${{ env.DOCKERHUB_PASSWORD && env.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Fixes #463 

Changes proposed in this PR:

- Using main branch of barge for tests (v4 branch doesn't exist anymore)