### PR TITLE
add event Index to pool transactions

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -207,7 +207,7 @@ type PoolShare @entity {
 }
 
 type PoolTransaction @entity {
-  "tx address + caller address" 
+  "tx address + eventIndex" 
   id: ID!        
   "pool related to this tx"                                            
   pool: Pool!   
@@ -222,6 +222,7 @@ type PoolTransaction @entity {
   timestamp: Int!      
   "pool creation transaction id"                            
   tx: String!    
+  eventIndex: BigInt
   "block number when it was created"                                          
   block: Int       
 

--- a/src/mappings/pool.ts
+++ b/src/mappings/pool.ts
@@ -32,7 +32,12 @@ import { getUser } from './utils/userUtils'
 export function handleJoin(event: LOG_JOIN): void {
   const pool = getPool(event.address.toHex())
   const user = getUser(event.params.caller.toHex())
-  const poolTx = getPoolTransaction(event, user.id, PoolTransactionType.JOIN)
+  const poolTx = getPoolTransaction(
+    event,
+    user.id,
+    PoolTransactionType.JOIN,
+    event.logIndex
+  )
 
   pool.transactionCount = pool.transactionCount.plus(integer.ONE)
   pool.joinCount = pool.joinCount.plus(integer.ONE)
@@ -72,7 +77,12 @@ export function handleJoin(event: LOG_JOIN): void {
 export function handleExit(event: LOG_EXIT): void {
   const pool = getPool(event.address.toHex())
   const user = getUser(event.params.caller.toHex())
-  const poolTx = getPoolTransaction(event, user.id, PoolTransactionType.EXIT)
+  const poolTx = getPoolTransaction(
+    event,
+    user.id,
+    PoolTransactionType.EXIT,
+    event.logIndex
+  )
 
   pool.transactionCount = pool.transactionCount.plus(integer.ONE)
   pool.joinCount = pool.joinCount.plus(integer.ONE)
@@ -109,7 +119,12 @@ export function handleExit(event: LOG_EXIT): void {
 export function handleSwap(event: LOG_SWAP): void {
   const pool = getPool(event.address.toHex())
   const user = getUser(event.params.caller.toHex())
-  const poolTx = getPoolTransaction(event, user.id, PoolTransactionType.SWAP)
+  const poolTx = getPoolTransaction(
+    event,
+    user.id,
+    PoolTransactionType.SWAP,
+    event.logIndex
+  )
 
   pool.transactionCount = pool.transactionCount.plus(integer.ONE)
   pool.joinCount = pool.joinCount.plus(integer.ONE)
@@ -227,7 +242,8 @@ export function handleSetup(event: LOG_SETUP): void {
   const poolTx = getPoolTransaction(
     event,
     fromUser.id,
-    PoolTransactionType.SETUP
+    PoolTransactionType.SETUP,
+    event.logIndex
   )
   poolTx.type = PoolTransactionType.SETUP
   poolTx.baseToken = token.id
@@ -259,7 +275,12 @@ export function handlerBptTransfer(event: Transfer): void {
   const toAddress = event.params.dst.toHexString()
   const poolAddress = event.address.toHex()
   const caller = getUser(event.transaction.from.toHex())
-  const poolTx = getPoolTransaction(event, caller.id, PoolTransactionType.SWAP)
+  const poolTx = getPoolTransaction(
+    event,
+    caller.id,
+    PoolTransactionType.SWAP,
+    event.logIndex
+  )
 
   // btoken has 18 decimals
   const ammount = weiToDecimal(event.params.amt.toBigDecimal(), 18)

--- a/src/mappings/utils/poolUtils.ts
+++ b/src/mappings/utils/poolUtils.ts
@@ -1,4 +1,4 @@
-import { Address, BigDecimal, ethereum } from '@graphprotocol/graph-ts'
+import { Address, BigDecimal, BigInt, ethereum } from '@graphprotocol/graph-ts'
 import {
   Pool,
   PoolShare,
@@ -19,19 +19,20 @@ export function getPoolShareId(
 
 export function getPoolTransactionId(
   txHash: string,
-  userAddress: string
+  eventIndex: BigInt
 ): string {
-  return `${txHash}-${userAddress}`
+  return `${txHash}-` + eventIndex.toString()
 }
 
 export function getPoolTransaction(
   event: ethereum.Event,
   userAddress: string,
-  type: string
+  type: string,
+  eventIndex: BigInt
 ): PoolTransaction {
   const txId = getPoolTransactionId(
     event.transaction.hash.toHexString(),
-    userAddress
+    eventIndex
   )
   let poolTx = PoolTransaction.load(txId)
 
@@ -45,6 +46,7 @@ export function getPoolTransaction(
 
     poolTx.timestamp = event.block.timestamp.toI32()
     poolTx.tx = event.transaction.hash.toHex()
+    poolTx.eventIndex = eventIndex
     poolTx.block = event.block.number.toI32()
 
     poolTx.gasPrice = gweiToEth(event.transaction.gasPrice.toBigDecimal())


### PR DESCRIPTION
Changes proposed in this PR:

- add event index to pool transactions, so we can track multiple pool events in one tx
- 

Query example:
```
query{
 poolTransactions{
  id,
  tx
  type
  eventIndex
}
}
```

Result:
```
{
  "data": {
    "poolTransactions": [
      {
        "id": "0x00128a5bbb7ca28de2f28ab78d6c4d2a3b8dfef1f1f9f65545a295903cec3e32-283",
        "tx": "0x00128a5bbb7ca28de2f28ab78d6c4d2a3b8dfef1f1f9f65545a295903cec3e32",
        "type": "EXIT",
        "eventIndex": "283"
      },
      {
        "id": "0x00128a5bbb7ca28de2f28ab78d6c4d2a3b8dfef1f1f9f65545a295903cec3e32-285",
        "tx": "0x00128a5bbb7ca28de2f28ab78d6c4d2a3b8dfef1f1f9f65545a295903cec3e32",
        "type": "EXIT",
        "eventIndex": "285"
      },
      {
        "id": "0x00128a5bbb7ca28de2f28ab78d6c4d2a3b8dfef1f1f9f65545a295903cec3e32-286",
        "tx": "0x00128a5bbb7ca28de2f28ab78d6c4d2a3b8dfef1f1f9f65545a295903cec3e32",
        "type": "SWAP",
        "eventIndex": "286"
      },
      {
        "id": "0x00128a5bbb7ca28de2f28ab78d6c4d2a3b8dfef1f1f9f65545a295903cec3e32-287",
        "tx": "0x00128a5bbb7ca28de2f28ab78d6c4d2a3b8dfef1f1f9f65545a295903cec3e32",
        "type": "SWAP",
        "eventIndex": "287"
      },
      {
        "id": "0x00128a5bbb7ca28de2f28ab78d6c4d2a3b8dfef1f1f9f65545a295903cec3e32-290",
        "tx": "0x00128a5bbb7ca28de2f28ab78d6c4d2a3b8dfef1f1f9f65545a295903cec3e32",
        "type": "SWAP",
        "eventIndex": "290"
      },
      {
        "id": "0x00128a5bbb7ca28de2f28ab78d6c4d2a3b8dfef1f1f9f65545a295903cec3e32-291",
        "tx": "0x00128a5bbb7ca28de2f28ab78d6c4d2a3b8dfef1f1f9f65545a295903cec3e32",
        "type": "SWAP",
        "eventIndex": "291"
      },
      ....
}
```