### PR TITLE
fix allocation

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -474,7 +474,7 @@ type VeOCEAN @entity {
   delegates: [VeDelegation!] @derivedFrom(field: "receiver")
   deposits: [VeDeposit!] @derivedFrom(field: "veOcean")
   claims: [VeClaim!] @derivedFrom(field: "veOcean")
-  allocation: VeAllocateUser! @derivedFrom(field: "veOcean")
+  allocation: [VeAllocateUser!] @derivedFrom(field: "veOcean")
   block: Int!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -474,7 +474,7 @@ type VeOCEAN @entity {
   delegates: [VeDelegation!] @derivedFrom(field: "receiver")
   deposits: [VeDeposit!] @derivedFrom(field: "veOcean")
   claims: [VeClaim!] @derivedFrom(field: "veOcean")
-  allocation: [VeAllocateUser!] @derivedFrom(field: "veOcean")
+  allocation: VeAllocateUser @derivedFrom(field: "veOcean")
   block: Int!
 }
 


### PR DESCRIPTION
Not all users will have allocations:

In the current setup:
```
query{
    veOCEANs{
    id
    lockedAmount
    unlockTime
    deposits{
      provider
      sender
      value
      unlockTime
      timestamp
      type
    }
    claims{
      amount
      claim_epoch
      max_epoch
      timestamp
    }
    allocation{
      id
      allocatedTotal
    }
   }
   ```
   
   might return:
   ```
   {
  "errors": [
    {
      "locations": [
        {
          "column": 5,
          "line": 20
        }
      ],
      "message": "Null value resolved for non-null field `allocation`"
    },
    {
      "locations": [
        {
          "line": 20,
          "column": 5
        }
      ],
      "message": "Null value resolved for non-null field `allocation`"
    },
    {
      "locations": [
        {
          "line": 20,
          "column": 5
        }
      ],
      "message": "Null value resolved for non-null field `allocation`"
    },
```


Simple fix is attached