### PR TITLE
Add missing veDelegation.save() to veDelegation BurnBoost handler

### DIFF
--- a/src/mappings/veDelegation.ts
+++ b/src/mappings/veDelegation.ts
@@ -64,4 +64,5 @@ export function handleBurnBoost(event: BurnBoost): void {
   // delete
   const veDelegation = getveDelegation(_tokenId.toHex())
   veDelegation.amount = BigInt.zero()
+  veDelegation.save()
 }


### PR DESCRIPTION
Fixes #657

Changes proposed in this PR:

- Add missing veDelegation.save() to veDelegation BurnBoost handler